### PR TITLE
[DOC] Remove unnecessary author note from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,6 @@ Things to mention:
 - how to add new libraries and integrate them to build tools
 - ...
 
-`MAYBE AS SEPARATE DOCUMENTATION TO KEEP THIS README SHORT`
 
 ### Branching
 The `master` branch contains latest stable releases. The `develop` branch is the main development branch that will be merged into the `master` branch from time to time. Any other branch focuses certain bug fixes or feature requests.


### PR DESCRIPTION
"Removed the hanging line in the 'Hints on how to integrate a new Module' section as it appeared to be an author's internal note, not part of the final documentation."